### PR TITLE
[OC-41162] sf(deprecations): Change ConnectionMock inheritance to avoid deprecation

### DIFF
--- a/Tests/DependencyInjection/Fixtures/Util/ConnectionMock.php
+++ b/Tests/DependencyInjection/Fixtures/Util/ConnectionMock.php
@@ -2,12 +2,15 @@
 
 namespace OpenClassrooms\Bundle\UseCaseBundle\Tests\DependencyInjection\Fixtures\Util;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
 
 /**
  * @author Romain Kuzniak <romain.kuzniak@turn-it-up.org>
  */
-class ConnectionMock extends Connection
+class ConnectionMock implements DriverConnection
 {
     /**
      * @var bool
@@ -36,7 +39,7 @@ class ConnectionMock extends Connection
         self::$rollBacked = false;
     }
 
-    public function getConnection()
+    public function getConnection(): self
     {
         return new ConnectionMock();
     }
@@ -65,5 +68,61 @@ class ConnectionMock extends Connection
     public function isTransactionActive()
     {
         return self::$transactionNumber > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prepare($sql)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function query()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function exec($sql)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function lastInsertId($name = null)
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function errorCode()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function errorInfo()
+    {
+        return null;
     }
 }

--- a/Tests/DependencyInjection/Fixtures/Util/EventDispatcherSpy.php
+++ b/Tests/DependencyInjection/Fixtures/Util/EventDispatcherSpy.php
@@ -25,7 +25,7 @@ class EventDispatcherSpy extends EventDispatcher
         self::$sent = false;
     }
 
-    public function dispatch($event, string $eventName = null)
+    public function dispatch(object $event, string $eventName = null): object
     {
         self::$eventName = $eventName;
         self::$sent = true;


### PR DESCRIPTION
# Description

This PR fix the deprecation about the ConnectionMock.
ConnectionMock inherits from DBAL\Connection but we should not use the constructor of that class (deprecated).
So I implements the Doctrine Driver connection directly, and added few dummy methods to comply with the interface.

The goal is to add a tag v2.1.3 on this repo and integrate it in SdZv4.

The only test using ConnectionMock seems to be UuidV6GeneratorTest

[JIRA-41162](https://simple-it.atlassian.net/browse/OC-41162)

